### PR TITLE
Add ability to set days in year

### DIFF
--- a/src/main/java/org/decampo/xirr/Xirr.java
+++ b/src/main/java/org/decampo/xirr/Xirr.java
@@ -122,7 +122,7 @@ public class Xirr {
             throw new IllegalArgumentException(
                 "Must have at least two transactions");
         }
-        if (daysInYear < 0) {
+        if (daysInYear <= 0) {
             throw new IllegalArgumentException("Days in year must be positive: " + daysInYear);
         }
         this.daysInYear = daysInYear;

--- a/src/test/java/org/decampo/xirr/XirrBuilderTest.java
+++ b/src/test/java/org/decampo/xirr/XirrBuilderTest.java
@@ -51,6 +51,19 @@ public class XirrBuilderTest {
     }
 
     @Test
+    public void withTransactions_1_year_decline_360days() {
+        // computes the negative xirr on 1 year decline of 10%
+        final double xirr = Xirr.builder()
+                .withTransactions(
+                        new Transaction(-1000, "2010-01-01"),
+                        new Transaction(  900, "2011-01-01")
+                )
+                .withDaysInYear(360)
+                .xirr();
+        assertEquals(-0.0987, xirr, TOLERANCE);
+    }
+
+    @Test
     public void withNewtonRaphsonBuilder() throws Exception {
         final double expected = 1;
 

--- a/src/test/java/org/decampo/xirr/XirrTest.java
+++ b/src/test/java/org/decampo/xirr/XirrTest.java
@@ -180,6 +180,25 @@ public class XirrTest {
     }
 
     @Test
+    public void xirr_with360daysPerYear() {
+        double rate = new Xirr(
+                360,
+                new Transaction(-2610, "2001-06-22"),
+                new Transaction(-2589, "2001-07-03"),
+                new Transaction(-5110, "2001-07-05"),
+                new Transaction(-2550, "2001-07-06"),
+                new Transaction(-5086, "2001-07-09"),
+                new Transaction(-2561, "2001-07-10"),
+                new Transaction(-5040, "2001-07-12"),
+                new Transaction(-2552, "2001-07-13"),
+                new Transaction(-2530, "2001-07-16"),
+                new Transaction(-9840, "2001-07-17"),
+                new Transaction(38900, "2001-07-18")
+        ).xirr();
+        assertEquals(-0.8312209, rate, TOLERANCE);
+    }
+
+    @Test
     public void xirr_implementing_issue_23_is_impossible() {
         double xirr = new Xirr(
                 new Transaction(-2000, "2010-01-01"),


### PR DESCRIPTION
Added the ability to set the days in year for both the constructor and builder approaches.

Default is 365 so that there is no regression impact

Test cases added to validate the results